### PR TITLE
add input for meltano version

### DIFF
--- a/.github/workflows/deploy-pipeline-aws.yml
+++ b/.github/workflows/deploy-pipeline-aws.yml
@@ -32,6 +32,9 @@ on:
       datateerCliVersion:
         description: Datateer CLI version. Leave blank to use the latest version. See https://pypi.org/project/datateer-cli/
         type: string
+      meltanoVersion:
+        description: Temporary fix until we are upgraded to Prefect 2.0. Specify the meltano version. 2.1 to 2.4 has a breaking change. Defaults to 2.1. Only set a value if you need something different
+        type: string
     secrets:
       deployKeyPrefectLib:
         description: The github deployment key that allows access to Datateer/datateer-prefect. This is available as an organization secret
@@ -56,6 +59,7 @@ jobs:
       CLIENT_CODE: ${{ inputs.clientCode || secrets.CLIENT_CODE }}
       DATATEER_ENV: ${{ inputs.environment || 'int' }}
       PIPELINE_NAME: ${{ inputs.pipeline_name || 'main' }}
+      MELTANO_ENV: ${{ inputs.meltanoVersion }}
     steps:
       - name: Checkout pipeline repo
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-pipeline-aws.yml
+++ b/.github/workflows/deploy-pipeline-aws.yml
@@ -33,7 +33,7 @@ on:
         description: Datateer CLI version. Leave blank to use the latest version. See https://pypi.org/project/datateer-cli/
         type: string
       meltanoVersion:
-        description: Temporary fix until we are upgraded to Prefect 2.0. Specify the meltano version. 2.1 to 2.4 has a breaking change. Defaults to 2.1. Only set a value if you need something different
+        description: Temporary fix until we are upgraded to Prefect 2.0. Specify "2.4.0" or leave blank to default to 2.1.0
         type: string
     secrets:
       deployKeyPrefectLib:


### PR DESCRIPTION
Until we get Prefect 2.0 released, meltano database upgrades can't happen. Some customers are on v2.4, others are on v2.1. 

There is a breaking change, so we cannot force everyone to one or the other. 

This assumes the datateer-cli will default to v2.1. If ou want 2.4, specify v2.4.0
